### PR TITLE
Add canvas translation for stage

### DIFF
--- a/src/main/matlab/+stage/+core/+network/StageClient.m
+++ b/src/main/matlab/+stage/+core/+network/StageClient.m
@@ -44,6 +44,12 @@ classdef StageClient < handle
             obj.sendReceive(e);
         end
         
+        function setCanvasProjectionTranslate(obj, x, y, z)
+            % Translates the remote canvas projection
+            e = netbox.NetEvent('setCanvasProjectionTranslate', {x, y, z});
+            obj.sendReceive(e);
+        end
+        
         function setCanvasProjectionOrthographic(obj, left, right, bottom, top)
             % Sets the remote canvas projection orthographic.
             e = netbox.NetEvent('setCanvasProjectionOrthographic', {left, right, bottom, top});

--- a/src/main/matlab/+stage/+core/+network/StageServer.m
+++ b/src/main/matlab/+stage/+core/+network/StageServer.m
@@ -96,6 +96,8 @@ classdef StageServer < handle
                         obj.onEventGetCanvasSize(connection, event);
                     case 'setCanvasProjectionIdentity'
                         obj.onEventSetCanvasProjectionIdentity(connection, event);
+                    case 'setCanvasProjectionTranslate'
+                        obj.onEventSetCanvasProjectionTranslate(connection, event);                        
                     case 'setCanvasProjectionOrthographic'
                         obj.onEventSetCanvasProjectionOrthographic(connection, event);
                     case 'resetCanvasProjection'
@@ -137,6 +139,14 @@ classdef StageServer < handle
         
         function onEventSetCanvasProjectionIdentity(obj, connection, event) %#ok<INUSD>
             obj.canvas.projection.setIdentity();
+            connection.sendEvent(netbox.NetEvent('ok'));
+        end
+        
+        function onEventSetCanvasProjectionTranslate(obj, connection, event)
+            x = event.arguments{1};
+            y = event.arguments{2};
+            z = event.arguments{3};
+            obj.canvas.projection.translate(x,y,z)
             connection.sendEvent(netbox.NetEvent('ok'));
         end
         


### PR DESCRIPTION
Adds the ability to shift all canvas items by an X, Y, (Z) value.
Does this by modifying the canvas' setting, so each call is relative to the previous value result. So, should probably be called only after resetting the projection, in order to get a known translation value.

Code for LightCrafterDevice:

```
function play(obj, presentation)
  canvasSize = obj.getCanvasSize();
  canvasTranslation = obj.getConfigurationSetting('canvasTranslation');
  obj.stageClient.setCanvasProjectionIdentity();
  obj.stageClient.setCanvasProjectionOrthographic(0, canvasSize(1), 0, canvasSize(2));            
  obj.stageClient.setCanvasProjectionTranslate(canvasTranslation(1), canvasTranslation(2), 0);
```
